### PR TITLE
Add encoding parameter

### DIFF
--- a/StringTools.php
+++ b/StringTools.php
@@ -21,53 +21,61 @@ class StringTools
     /**
      * @param string $str
      * @param string $start
+     * @param string $encoding
      * @return bool
      */
-    public static function startsWith($str, $start)
+    public static function startsWith($str, $start, $encoding = 'UTF-8')
     {
-        $length = mb_strlen($start);
-        return substr($str, 0, $length) === $start;
+        $length = mb_strlen($start, $encoding);
+
+        return mb_substr($str, 0, $length, $encoding) === $start;
     }
 
     /**
      * @param string $str
      * @param string $end
+     * @param string $encoding
      * @return bool
      */
-    public static function endsWith($str, $end)
+    public static function endsWith($str, $end, $encoding = 'UTF-8')
     {
-        $length = mb_strlen($end);
+        $length = mb_strlen($end, $encoding);
         if ($length === 0) {
             return true;
         }
-        return substr($str, -$length) === $end;
+
+        return mb_substr($str, -$length, $length, $encoding) === $end;
     }
 
     /**
      * @param string $str
      * @param string $toRemove
+     * @param string $encoding
      * @return string
      */
-    public static function removeStart($str, $toRemove)
+    public static function removeStart($str, $toRemove, $encoding = 'UTF-8')
     {
-        if (!StringTools::startsWith($str, $toRemove)) {
+        if (!StringTools::startsWith($str, $toRemove, $encoding)) {
             return $str;
         }
+        $sizeToRemove = mb_strlen($toRemove, $encoding);
 
-        return mb_substr($str, mb_strlen($toRemove));
+        return mb_substr($str, $sizeToRemove, mb_strlen($str, $encoding) - $sizeToRemove, $encoding);
     }
 
     /**
      * @param string $str       The string that should contains the needle
      * @param string $needle    What should be contained
+     * @param string $encoding
      * @return bool
      */
-    public static function contains($str, $needle)
+    public static function contains($str, $needle, $encoding = 'UTF-8')
     {
-        $position = strpos($str, $needle);
+        $position = mb_strpos($str, $needle, 0, $encoding);
         if ($position === 0) {
             return true;
         }
+
         return (bool) $position;
     }
 }

--- a/spec/Nekland/Tools/StringToolsSpec.php
+++ b/spec/Nekland/Tools/StringToolsSpec.php
@@ -15,11 +15,13 @@ class StringToolsSpec extends ObjectBehavior
     function it_should_transform_snake_case_to_camel_case()
     {
         $this::camelize('hello_world')->shouldReturn('HelloWorld');
+        $this::camelize('foo🍕')->shouldReturn('Foo🍕');
     }
 
     function it_should_transform_kebab_case_to_camel_case()
     {
         $this::camelize('hello-world', '-')->shouldReturn('HelloWorld');
+        $this::camelize('foo-🍕-bar', '-')->shouldReturn('Foo🍕Bar');
     }
 
     function it_should_not_transform_others_than_kebab_or_snake_case()
@@ -34,6 +36,7 @@ class StringToolsSpec extends ObjectBehavior
         $this::startsWith("\nLorem ipsum heyà", 'Lorem')->shouldReturn(false);
         $this::startsWith(' ipsum heyà Lorem', 'Lorem')->shouldReturn(false);
         $this::startsWith(' ipsum heyà Lorem', '')->shouldReturn(true);
+        $this::startsWith('Lorem 🍕 ipsum', 'Lorem 🍕')->shouldReturn(true);
     }
 
     function it_should_check_if_string_ends_with_needle()
@@ -43,11 +46,13 @@ class StringToolsSpec extends ObjectBehavior
         $this::endsWith('Foo bar marche baz ça ', 'marche')->shouldReturn(false);
         $this::endsWith('marche Foo bar baz ça ', 'marche')->shouldReturn(false);
         $this::endsWith('marche Foo bar baz ça ', '')->shouldReturn(true);
+        $this::endsWith('Hello my 🍕 world !', '🍕 world !')->shouldReturn(true);
     }
 
     function it_should_remove_the_start_of_a_string()
     {
         $this::removeStart('Foo bar baz', 'Foo')->shouldReturn(' bar baz');
+        $this::removeStart('I really ❤️ 🍕 !', 'I really ❤️')->shouldReturn(' 🍕 !');
         $this::removeStart('YOLOOOsgs gs gsg sggs g', 'g')->shouldReturn('YOLOOOsgs gs gsg sggs g');
     }
 
@@ -67,5 +72,7 @@ class StringToolsSpec extends ObjectBehavior
         $this::contains('Theres nothing to see here', 'there there')->shouldReturn(false);
         $this::contains('Hello everybody, how are you today ? :)', 'everybody, how')->shouldReturn(true);
         $this::contains('Hello world ! =)', '.+')->shouldReturn(false);
+        $this::contains('Hello world ! 😀', '! 😀')->shouldReturn(true);
+        $this::contains('Hello 👽 aliens !', 'aliens')->shouldReturn(true);
     }
 }


### PR DESCRIPTION
It fixes unicode processing
Take it as default encoding
And add the possibility to use methods with another encoding supported
by PHP.