### PR TITLE
Add ArrayTools to remove value in an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `ArrayTools` class helper
+- `ArrayTools::removeValue` method to remove a value from given array
 
 ## [2.1.0] - 2017-04-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This library provide some tools to help you with your developments.
 
 Here is the list of tools it provides:
 - [StringTools](#stringtools-class)
+- [ArrayTools](#arraytools-class)
 - [EqualableInterface](#equalableinterface)
 - [DateTimeComparator](#datetimecomparator-class)
 
@@ -90,6 +91,17 @@ StringTools::mb_ucfirst($str, $encoding) : string
 
 * `$str` string input
 * `$encoding` (optional, default "UTF-8") encoding of your input string
+
+### ArrayTools class
+
+#### ::removeValue
+
+```php
+ArrayTools::removeValue($array, $value) : void
+```
+
+* `$array` input array passed by reference
+* `$value` The value to remove from the $array
 
 ### EqualableInterface
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,14 @@
     "autoload": {
         "psr-4": { "Nekland\\Tools\\": "src/" }
     },
+    "require": {
+        "php": "^5.6 || ^7.0"
+    },
     "require-dev": {
-        "phpspec/phpspec": "^2.5"
-    }
+        "phpspec/phpspec": "^3.2",
+        "bossa/phpspec2-expect": "^2.3"
+    },
+    "_comment": [
+        "PHPSpec is limited to ^3.2 to keep compatibility with PHP5.6"
+    ]
 }

--- a/spec/Nekland/Tools/ArrayToolsSpec.php
+++ b/spec/Nekland/Tools/ArrayToolsSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Nekland\Tools;
+
+use Nekland\Tools\ArrayTools;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ArrayToolsSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Nekland\Tools\ArrayTools');
+    }
+
+    function it_should_remove_value()
+    {
+        $array = [
+            'foo',
+            'bar',
+        ];
+
+        ArrayTools::removeValue($array, $array[1]);
+
+        \expect($array)->toBe([$array[0]]);
+    }
+}

--- a/src/ArrayTools.php
+++ b/src/ArrayTools.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Nekland\Tools;
+
+class ArrayTools
+{
+    /**
+     * Remove a value from the list
+     *
+     * @param array $array The array in which we have to remove value
+     * @param mixed $value The value to remove from the list
+     */
+    public static function removeValue(array &$array, $value)
+    {
+        $index = \array_search($value, $array);
+        if (false !== $index) {
+            unset($array[$index]);
+        }
+    }
+}


### PR DESCRIPTION
This is a pain to always make a loop to check array values and remove one if needed. This PR creates a new Tools: `ArrayTools`.
It allows to make some processing in array.

- The goal of this PR is to easily remove a value contained in an array
- Update PHPSpec to newer version (+ install bossa expect)
- Add PHP version explicitly in composer file