### PR TITLE
DateTimeComparator now handle N parameters with same behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Modified - 2019-01-10
+- Update the DateTimeComparator functions to handle N parameters
 
 ## [2.4.0] - 2019-01-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,31 +126,24 @@ Method that you must implements to check if the object taking as parameter is eq
 
 ### DateTimeComparator class
 
+For following methods `lowest` and `greatest`, you can provide unlimited `DateTimeInterface` objects.
+Please note that non DateTimeInterface objects will be ignored by functions.
+
 #### ::greatest
 
-Compare two \DateTimeInterface and return the greatest
-_If one of given \DateTimeInterface parameters is null, return is the other one \DateTimeInterface_
-_If both \DateTimeInterface parameters are null, return is null_
+Compare \DateTimeInterface from parameters and return the greatest
 
 ```php
-DateTimeComparator::greatest($dateTime1, $dateTime2) : ?\DateTimeInterface
+DateTimeComparator::greatest($dateTime1, $dateTime2, $dateTime3, ...) : ?\DateTimeInterface
 ```
-
-* `$dateTime1` The first \DateTimeInterface or null
-* `$dateTime2` The second \DateTimeInterface or null
 
 #### ::lowest
 
-Compare two \DateTimeInterface and return the lowest
-_If one of given \DateTimeInterface parameters is null, return is the other one \DateTimeInterface_
-_If both \DateTimeInterface parameters are null, return is null_
+Compare \DateTimeInterface from parameters and return the lowest
 
 ```php
-DateTimeComparator::lowest($dateTime1, $dateTime2) : ?\DateTimeInterface
+DateTimeComparator::lowest($dateTime1, $dateTime2, $dateTime3, ...) : ?\DateTimeInterface
 ```
-
-* `$dateTime1` The first \DateTimeInterface or null
-* `$dateTime2` The second \DateTimeInterface or null
 
 ### Temporary file management
 

--- a/spec/Nekland/Tools/DateTimeComparatorSpec.php
+++ b/spec/Nekland/Tools/DateTimeComparatorSpec.php
@@ -2,14 +2,14 @@
 
 namespace spec\Nekland\Tools;
 
+use Nekland\Tools\DateTimeComparator;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class DateTimeComparatorSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Nekland\Tools\DateTimeComparator');
+        $this->shouldHaveType(DateTimeComparator::class);
     }
 
     function it_should_return_greatest_date_time()
@@ -31,7 +31,7 @@ class DateTimeComparatorSpec extends ObjectBehavior
         $this::greatest($dateTime2, $dateTime1)->shouldReturn($dateTime1);
         $this::greatest($dateTime1, null)->shouldReturn($dateTime1);
         $this::greatest(null, $dateTime1)->shouldReturn($dateTime1);
-        
+
         $this::greatest(null, null)->shouldReturn(null);
     }
 
@@ -54,7 +54,24 @@ class DateTimeComparatorSpec extends ObjectBehavior
         $this::lowest($dateTime2, $dateTime1)->shouldReturn($dateTime1);
         $this::lowest($dateTime1, null)->shouldReturn($dateTime1);
         $this::lowest(null, $dateTime1)->shouldReturn($dateTime1);
-        
+
         $this::lowest(null, null)->shouldReturn(null);
+    }
+
+    function it_should_can_handle_multiple_datetimes()
+    {
+        $dateTime1 = new \DateTimeImmutable();
+        $dateTime2 = new \DateTimeImmutable('+2 days');
+        $dateTime3 = new \DateTimeImmutable('+4 days');
+        $dateTime4 = new \DateTimeImmutable('+6 days');
+
+        $this::lowest($dateTime2, $dateTime1, $dateTime4, $dateTime3)->shouldReturn($dateTime1);
+        $this::greatest($dateTime3, $dateTime4, $dateTime1, $dateTime2)->shouldReturn($dateTime4);
+    }
+
+    function it_should_return_null_if_no_datetime_given()
+    {
+        $this::lowest('this', 'is', 0, false, new \Exception())->shouldReturn(null);
+        $this::greatest('this', 'is', 0, false, new \Exception())->shouldReturn(null);
     }
 }

--- a/src/Tools/DateTimeComparator.php
+++ b/src/Tools/DateTimeComparator.php
@@ -5,57 +5,44 @@ namespace Nekland\Tools;
 class DateTimeComparator
 {
     /**
-     * Get the greatest DateTime between the twice given as parameter
-     * If one DateTime is null, return the other
-     * If the twice DateTime are null, return null
+     * Get the greatest "DateTimeInterface" from the parameters
+     * @param mixed $datetimes,... A various number of instances implementing `DateTimeInterface`
+     * @return \DateTimeInterface|null
      */
-    public static function greatest(\DateTimeInterface $dateTime1 = null, \DateTimeInterface $dateTime2 = null)
+    public static function greatest(... $datetimes)
     {
-        // - If one DateTime is null, return the other date
-        // - If the twice DateTime are null, return null
-        if (\is_null($dateTime1) || \is_null($dateTime2)) {
-            return self::getNonNullableDateTime($dateTime1, $dateTime2);
+        $greatest = null;
+        foreach ($datetimes as $datetime) {
+            if (!$datetime instanceof \DateTimeInterface) {
+                continue;
+            }
+
+            if ($datetime > $greatest || null === $greatest) {
+                $greatest = $datetime;
+            }
         }
 
-        return $dateTime1 > $dateTime2 ? $dateTime1 : $dateTime2;
+        return $greatest;
     }
 
     /**
-     * Get the lowest DateTime between the twice given as parameter
-     * If one DateTime is null, return the other
-     * If the twice DateTime are null, return null
+     * Get the lowest "DateTimeInterface" from the parameters
+     * @param mixed $datetimes,... A various number of instances implementing `DateTimeInterface`
+     * @return \DateTimeInterface|null
      */
-    public static function lowest(\DateTimeInterface $dateTime1 = null, \DateTimeInterface $dateTime2 = null)
+    public static function lowest(... $datetimes)
     {
-        // - If one DateTime is null, return the other date
-        // - If the twice DateTime are null, return null
-        if (\is_null($dateTime1) || \is_null($dateTime2)) {
-            return self::getNonNullableDateTime($dateTime1, $dateTime2);
+        $lowest = null;
+        foreach ($datetimes as $datetime) {
+            if (!$datetime instanceof \DateTimeInterface) {
+                continue;
+            }
+
+            if ($datetime < $lowest || null === $lowest) {
+                $lowest = $datetime;
+            }
         }
 
-        return $dateTime1 < $dateTime2 ? $dateTime1 : $dateTime2;
-    }
-
-    /**
-     * Check which DateTime parameter is null
-     * Use this method when you know that at least one or more DateTime is/are null
-     * - Only one DateTime is null: return the other one which is the greatest/lowest DateTime by default
-     * - The twice DateTime are null: return null since no DateTime could be returned
-     */
-    private static function getNonNullableDateTime(\DateTimeInterface $dateTime1 = null, \DateTimeInterface $dateTime2 = null)
-    {
-        if (\is_null($dateTime1) && \is_null($dateTime2)) {
-            return null;
-        }
-
-        // If date1 is null, the only result can be date2
-        if (\is_null($dateTime1)) {
-            return $dateTime2;
-        }
-
-        // If date2 is null, the only result can be date1
-        if (\is_null($dateTime2)) {
-            return $dateTime1;
-        }
+        return $lowest;
     }
 }


### PR DESCRIPTION
The `DateTimeComparator` class functions now handle `N` parameters

No modification of behavior 

Tests updated