### PR TITLE
Add ability to not normalize on camelize

### DIFF
--- a/spec/Nekland/Tools/StringToolsSpec.php
+++ b/spec/Nekland/Tools/StringToolsSpec.php
@@ -15,18 +15,24 @@ class StringToolsSpec extends ObjectBehavior
     function it_should_transform_snake_case_to_camel_case()
     {
         $this::camelize('hello_world')->shouldReturn('HelloWorld');
-        $this::camelize('foo🍕')->shouldReturn('Foo🍕');
+        $this::camelize('foo🍕', '-', 'UTF-8', false)->shouldReturn('Foo🍕');
     }
 
     function it_should_transform_kebab_case_to_camel_case()
     {
         $this::camelize('hello-world', '-')->shouldReturn('HelloWorld');
-        $this::camelize('foo-🍕-bar', '-')->shouldReturn('Foo🍕Bar');
+        $this::camelize('foo-🍕-bar', '-', 'UTF-8', false)->shouldReturn('Foo🍕Bar');
     }
 
     function it_should_be_able_to_camelize_anything()
     {
         $this::camelize('something cool', ' ')->shouldReturn('SomethingCool');
+    }
+
+    function it_should_be_able_to_not_normalize_as_well_as_normalize_on_camelize()
+    {
+        $this::camelize('hello-theWorld', '-', 'UTF-8', false)->shouldReturn('HelloTheWorld');
+        $this::camelize('hello-the (world)', '-')->shouldReturn('HelloTheworld');
     }
 
     function it_should_check_if_string_starts_with_needle()

--- a/src/Tools/StringTools.php
+++ b/src/Tools/StringTools.php
@@ -8,20 +8,29 @@ class StringTools
      * @param string $str
      * @param string $from
      * @param string $encoding
+     * @param bool $normalize  Removes the formatting inside parts of the given strings. Makes sense most part of the time.
      * @return string
      */
-    public static function camelize($str, $from = '_', $encoding = 'UTF-8')
+    public static function camelize($str, $from = '_', $encoding = 'UTF-8', $normalize = true)
     {
+        $items = explode($from, $str);
+
+        if ($normalize) {
+            $items = array_map(function ($item) use ($encoding) {
+                // Removes special characters
+                $item = preg_replace('/[^A-Za-z0-9]/', '', $item);
+                // Lowercase the whole string (otherwise it's not camelize)
+                return mb_strtolower($item, $encoding);
+            }, $items);
+        }
+
         return implode('',
             array_map(
-                // Up the first letter for each sub string
+            // Up the first letter for each sub string
                 function ($item) use ($encoding) {
                     return StringTools::mb_ucfirst($item, $encoding);
                 },
-                // Lowercase the whole string (otherwise it's not camelize)
-                array_map(function ($item) use ($encoding) {
-                    return mb_strtolower($item, $encoding);
-                }, explode($from, $str))
+                $items
             )
         );
     }


### PR DESCRIPTION
Problem: if you have a string like something_toCamelize you probably
want to keep the last part camelized. With the auto-normalization this
is not possible.

Solution: adding a new option on the method so you can disable
normalization. I also make the normalization more powerful with a little
classi regex.