### PR TITLE
fix(temp-dir): allow to create a temporary directory for an existing dir path

### DIFF
--- a/src/Utils/Tempfile/TemporaryDirectory.php
+++ b/src/Utils/Tempfile/TemporaryDirectory.php
@@ -10,6 +10,7 @@
 
 namespace Nekland\Utils\Tempfile;
 
+use Nekland\Utils\Exception\LogicException;
 use Nekland\Utils\Tempfile\Exception\ImpossibleToCreateDirectoryException;
 
 class TemporaryDirectory
@@ -24,18 +25,21 @@ class TemporaryDirectory
     private $removed;
 
     /**
-     * TemporaryDirectory constructor.
-     *
      * @param null|string $dir
      * @param string      $prefix
      */
-    public function __construct($dir = null, $prefix = 'phpgenerated')
+    public function __construct(string $dir = null, string $prefix = 'phpgenerated')
     {
         $this->removed = false;
         $this->wasAlreadyExisting = false;
         if (null !== $dir && \is_dir($dir)) {
+            if (!is_writable($dir)) {
+                throw new LogicException(\sprintf('The directory "%s" is not writeable.', $dir));
+            }
+
             $this->wasAlreadyExisting = true;
             $this->dir = $dir;
+            return;
         }
 
         if (null === $this->dir) {

--- a/tests/Nekland/Utils/Tempfile/TemporaryDirectoryTest.php
+++ b/tests/Nekland/Utils/Tempfile/TemporaryDirectoryTest.php
@@ -36,4 +36,26 @@ class TemporaryDirectoryTest extends TestCase
         $directory->remove(true);
         $this->assertTrue($directory->hasBeenRemoved());
     }
+
+    public function testCreateATempDirectoryAtAnExistingPathIsAllowed()
+    {
+        $directory = new TemporaryDirectory();
+        $path = $directory->getPathname();
+        new TemporaryDirectory($path);
+
+        $this->assertDirectoryExists($path);
+
+        $directory->remove();
+    }
+
+    public function testCreateTemporaryFileForNotWritableDirThrowException()
+    {
+        $path = sys_get_temp_dir() . '/testwritable' . uniqid('', true);
+        mkdir($path, 0444);
+        $this->assertDirectoryExists($path);
+
+        $this->expectExceptionMessage("The directory \"$path\" is not writeable.");
+        new TemporaryDirectory($path);
+        unlink($path);
+    }
 }


### PR DESCRIPTION
+ throw an exception when user given dir path is not writeable