### PR TITLE
feat: remove custom dev dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ 7.3, 7.4, 8.0 ]
+                php: [ 7.4, 8.0 ]
                 os: [ ubuntu-latest ]
                 phpunit-versions: ['latest']
                 include:
@@ -18,7 +18,7 @@ jobs:
                         composer-flag: "--ignore-platform-reqs"
 
                     -   os: [ ubuntu-latest ]
-                        php: 7.2
+                        php: 7.3
                         composer-flag: "--prefer-lowest"
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,10 @@
     },
     "require-dev": {
         "phpspec/phpspec": "^6.3.0",
-        "bossa/phpspec2-expect": "dev-feature/php-8",
+        "friends-of-phpspec/phpspec-expect": "^4.0",
         "phpunit/phpunit": "^8.5"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Nek-/phpspec2-expect"
-        }
-    ],
     "_comment": [
-        "PHPSpec is limited to ^6.x to keep compatibility with PHP7.1",
-        "The repository for expect package is temporary, see https://github.com/BossaConsulting/phpspec2-expect/pull/66"
+        "PHPSpec is limited to ^6.x to keep compatibility with PHP7.1"
     ]
 }


### PR DESCRIPTION
Friends of PHPSpec are doing a great job maintaining phpspec-expect and
it seems working great! Let's remove our custom repository :) .

Sadly it will work only for PHP 7.3+ besides Nekland tools should be compatible with PHP 7.0+