### PR TITLE
Testsuite working on php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^7.0 || ^8.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^6.3.0",
+        "phpspec/phpspec": "^7.2.0",
         "friends-of-phpspec/phpspec-expect": "^4.0",
         "phpunit/phpunit": "^8.5"
     },


### PR DESCRIPTION
It was wating for the last version of phpspec which is out now :) .